### PR TITLE
Implement streamLog and taggedLogger extensions

### DIFF
--- a/stream-log/api/stream-log.api
+++ b/stream-log/api/stream-log.api
@@ -28,28 +28,20 @@ public final class io/getstream/log/SilentStreamLogger : io/getstream/log/Stream
 public final class io/getstream/log/StreamLog {
 	public static final field INSTANCE Lio/getstream/log/StreamLog;
 	public static final fun a (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun a$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun d$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun e$default (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
-	public static synthetic fun e$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun getInternalLogger ()Lio/getstream/log/StreamLogger;
 	public final fun getInternalValidator ()Lio/getstream/log/IsLoggableValidator;
 	public static final fun getLogger (Ljava/lang/String;)Lio/getstream/log/TaggedLogger;
-	public static synthetic fun getLogger$default (Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/log/TaggedLogger;
 	public static final fun i (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun i$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun inspect (Lkotlin/jvm/functions/Function1;)Z
 	public static final fun log (Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun log$default (Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun setLogger (Lio/getstream/log/StreamLogger;)V
 	public static final fun setValidator (Lio/getstream/log/IsLoggableValidator;)V
 	public static final fun v (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun v$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun w (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
-	public static synthetic fun w$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 
 public final class io/getstream/log/StreamLogExtensionKt {

--- a/stream-log/api/stream-log.api
+++ b/stream-log/api/stream-log.api
@@ -27,6 +27,7 @@ public final class io/getstream/log/SilentStreamLogger : io/getstream/log/Stream
 
 public final class io/getstream/log/StreamLog {
 	public static final field INSTANCE Lio/getstream/log/StreamLog;
+	public static final fun a (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
@@ -35,10 +36,18 @@ public final class io/getstream/log/StreamLog {
 	public static final fun getLogger (Ljava/lang/String;)Lio/getstream/log/TaggedLogger;
 	public static final fun i (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun inspect (Lkotlin/jvm/functions/Function1;)Z
+	public static final fun log (Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun log$default (Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun setLogger (Lio/getstream/log/StreamLogger;)V
 	public static final fun setValidator (Lio/getstream/log/IsLoggableValidator;)V
 	public static final fun v (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun w (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+}
+
+public final class io/getstream/log/StreamLogExtensionKt {
+	public static final fun outerClassSimpleTagName (Ljava/lang/Object;)Ljava/lang/String;
+	public static final fun streamLog (Ljava/lang/Object;Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun streamLog$default (Ljava/lang/Object;Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 
 public abstract interface class io/getstream/log/StreamLogger {

--- a/stream-log/api/stream-log.api
+++ b/stream-log/api/stream-log.api
@@ -28,20 +28,28 @@ public final class io/getstream/log/SilentStreamLogger : io/getstream/log/Stream
 public final class io/getstream/log/StreamLog {
 	public static final field INSTANCE Lio/getstream/log/StreamLog;
 	public static final fun a (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun a$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun d$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static synthetic fun e$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun getInternalLogger ()Lio/getstream/log/StreamLogger;
 	public final fun getInternalValidator ()Lio/getstream/log/IsLoggableValidator;
 	public static final fun getLogger (Ljava/lang/String;)Lio/getstream/log/TaggedLogger;
+	public static synthetic fun getLogger$default (Ljava/lang/String;ILjava/lang/Object;)Lio/getstream/log/TaggedLogger;
 	public static final fun i (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun i$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun inspect (Lkotlin/jvm/functions/Function1;)Z
 	public static final fun log (Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun log$default (Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun setLogger (Lio/getstream/log/StreamLogger;)V
 	public static final fun setValidator (Lio/getstream/log/IsLoggableValidator;)V
 	public static final fun v (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun v$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public static final fun w (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun w$default (Ljava/lang/String;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 }
 
 public final class io/getstream/log/StreamLogExtensionKt {

--- a/stream-log/api/stream-log.api
+++ b/stream-log/api/stream-log.api
@@ -48,6 +48,8 @@ public final class io/getstream/log/StreamLogExtensionKt {
 	public static final fun outerClassSimpleTagName (Ljava/lang/Object;)Ljava/lang/String;
 	public static final fun streamLog (Ljava/lang/Object;Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static synthetic fun streamLog$default (Ljava/lang/Object;Lio/getstream/log/Priority;Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
+	public static final fun taggedLogger (Ljava/lang/Object;Ljava/lang/String;)Lkotlin/Lazy;
+	public static synthetic fun taggedLogger$default (Ljava/lang/Object;Ljava/lang/String;ILjava/lang/Object;)Lkotlin/Lazy;
 }
 
 public abstract interface class io/getstream/log/StreamLogger {

--- a/stream-log/src/main/java/io/getstream/log/StreamLog.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLog.kt
@@ -78,7 +78,10 @@ public object StreamLog {
      * @return [TaggedLogger] Tagged logger.
      */
     @JvmStatic
-    public fun getLogger(tag: String): TaggedLogger = TaggedLogger(tag, internalLogger, internalValidator)
+    public fun getLogger(tag: String? = null): TaggedLogger {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        return TaggedLogger(tagOrCaller, internalLogger, internalValidator)
+    }
 
     /**
      * Send a [ERROR] log message.
@@ -88,9 +91,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun e(tag: String, throwable: Throwable, message: () -> String) {
-        if (internalValidator.isLoggable(ERROR, tag)) {
-            internalLogger.log(ERROR, tag, message(), throwable)
+    public inline fun e(tag: String? = null, throwable: Throwable? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(ERROR, tagOrCaller)) {
+            internalLogger.log(ERROR, tagOrCaller, message(), throwable)
         }
     }
 
@@ -101,9 +105,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun e(tag: String, message: () -> String) {
-        if (internalValidator.isLoggable(ERROR, tag)) {
-            internalLogger.log(ERROR, tag, message())
+    public inline fun e(tag: String? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(ERROR, tagOrCaller)) {
+            internalLogger.log(ERROR, tagOrCaller, message())
         }
     }
 
@@ -114,9 +119,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun w(tag: String, message: () -> String) {
-        if (internalValidator.isLoggable(WARN, tag)) {
-            internalLogger.log(WARN, tag, message())
+    public inline fun w(tag: String? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(WARN, tagOrCaller)) {
+            internalLogger.log(WARN, tagOrCaller, message())
         }
     }
 
@@ -127,9 +133,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun i(tag: String, message: () -> String) {
-        if (internalValidator.isLoggable(INFO, tag)) {
-            internalLogger.log(INFO, tag, message())
+    public inline fun i(tag: String? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(INFO, tagOrCaller)) {
+            internalLogger.log(INFO, tagOrCaller, message())
         }
     }
 
@@ -140,9 +147,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun d(tag: String, message: () -> String) {
-        if (internalValidator.isLoggable(DEBUG, tag)) {
-            internalLogger.log(DEBUG, tag, message())
+    public inline fun d(tag: String? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(DEBUG, tagOrCaller)) {
+            internalLogger.log(DEBUG, tagOrCaller, message())
         }
     }
 
@@ -153,9 +161,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun v(tag: String, message: () -> String) {
-        if (internalValidator.isLoggable(VERBOSE, tag)) {
-            internalLogger.log(VERBOSE, tag, message())
+    public inline fun v(tag: String? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(VERBOSE, tagOrCaller)) {
+            internalLogger.log(VERBOSE, tagOrCaller, message())
         }
     }
 
@@ -166,9 +175,10 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun a(tag: String, message: () -> String) {
-        if (internalValidator.isLoggable(ASSERT, tag)) {
-            internalLogger.log(ASSERT, tag, message())
+    public inline fun a(tag: String? = null, message: () -> String) {
+        val tagOrCaller = tag ?: outerClassSimpleTagName()
+        if (internalValidator.isLoggable(ASSERT, tagOrCaller)) {
+            internalLogger.log(ASSERT, tagOrCaller, message())
         }
     }
 

--- a/stream-log/src/main/java/io/getstream/log/StreamLog.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLog.kt
@@ -32,6 +32,7 @@ import io.getstream.log.Priority.WARN
  * The order in terms of verbosity, from least to most is [ERROR], [WARN], [INFO], [DEBUG], [VERBOSE].
  *
  */
+@Suppress("TooManyFunctions")
 public object StreamLog {
 
     /**

--- a/stream-log/src/main/java/io/getstream/log/StreamLog.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLog.kt
@@ -16,6 +16,7 @@
 
 package io.getstream.log
 
+import io.getstream.log.Priority.ASSERT
 import io.getstream.log.Priority.DEBUG
 import io.getstream.log.Priority.ERROR
 import io.getstream.log.Priority.INFO
@@ -155,6 +156,38 @@ public object StreamLog {
     public inline fun v(tag: String, message: () -> String) {
         if (internalValidator.isLoggable(VERBOSE, tag)) {
             internalLogger.log(VERBOSE, tag, message())
+        }
+    }
+
+    /**
+     * Send a [ASSERT] log message.
+     *
+     * @param tag Used to identify the source of a log message.
+     * @param message The function returning a message you would like logged.
+     */
+    @JvmStatic
+    public inline fun a(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(ASSERT, tag)) {
+            internalLogger.log(ASSERT, tag, message())
+        }
+    }
+
+    /**
+     * Send a log message according to the [priority].
+     *
+     * @param priority The priority/type of this log message.
+     * @param tag Used to identify the source of a log message.
+     * @param message The function returning a message you would like logged.
+     */
+    @JvmStatic
+    public inline fun log(priority: Priority, tag: String, message: () -> String) {
+        when (priority) {
+            VERBOSE -> v(tag, message)
+            DEBUG -> d(tag, message)
+            INFO -> i(tag, message)
+            WARN -> w(tag, message)
+            ERROR -> e(tag, message)
+            ASSERT -> a(tag, message)
         }
     }
 }

--- a/stream-log/src/main/java/io/getstream/log/StreamLog.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLog.kt
@@ -178,16 +178,21 @@ public object StreamLog {
      * @param priority The priority/type of this log message.
      * @param tag Used to identify the source of a log message.
      * @param message The function returning a message you would like logged.
+     * @param throwable An exception to log.
      */
     @JvmStatic
-    public inline fun log(priority: Priority, tag: String, message: () -> String) {
-        when (priority) {
-            VERBOSE -> v(tag, message)
-            DEBUG -> d(tag, message)
-            INFO -> i(tag, message)
-            WARN -> w(tag, message)
-            ERROR -> e(tag, message)
-            ASSERT -> a(tag, message)
+    public inline fun log(priority: Priority, tag: String, throwable: Throwable? = null, message: () -> String) {
+        if (throwable != null) {
+            e(tag, throwable, message)
+        } else {
+            when (priority) {
+                VERBOSE -> v(tag, message)
+                DEBUG -> d(tag, message)
+                INFO -> i(tag, message)
+                WARN -> w(tag, message)
+                ERROR -> e(tag, message)
+                ASSERT -> a(tag, message)
+            }
         }
     }
 }

--- a/stream-log/src/main/java/io/getstream/log/StreamLog.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLog.kt
@@ -78,10 +78,7 @@ public object StreamLog {
      * @return [TaggedLogger] Tagged logger.
      */
     @JvmStatic
-    public fun getLogger(tag: String? = null): TaggedLogger {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        return TaggedLogger(tagOrCaller, internalLogger, internalValidator)
-    }
+    public fun getLogger(tag: String): TaggedLogger = TaggedLogger(tag, internalLogger, internalValidator)
 
     /**
      * Send a [ERROR] log message.
@@ -91,10 +88,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun e(tag: String? = null, throwable: Throwable? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(ERROR, tagOrCaller)) {
-            internalLogger.log(ERROR, tagOrCaller, message(), throwable)
+    public inline fun e(tag: String, throwable: Throwable, message: () -> String) {
+        if (internalValidator.isLoggable(ERROR, tag)) {
+            internalLogger.log(ERROR, tag, message(), throwable)
         }
     }
 
@@ -105,10 +101,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun e(tag: String? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(ERROR, tagOrCaller)) {
-            internalLogger.log(ERROR, tagOrCaller, message())
+    public inline fun e(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(ERROR, tag)) {
+            internalLogger.log(ERROR, tag, message())
         }
     }
 
@@ -119,10 +114,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun w(tag: String? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(WARN, tagOrCaller)) {
-            internalLogger.log(WARN, tagOrCaller, message())
+    public inline fun w(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(WARN, tag)) {
+            internalLogger.log(WARN, tag, message())
         }
     }
 
@@ -133,10 +127,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun i(tag: String? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(INFO, tagOrCaller)) {
-            internalLogger.log(INFO, tagOrCaller, message())
+    public inline fun i(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(INFO, tag)) {
+            internalLogger.log(INFO, tag, message())
         }
     }
 
@@ -147,10 +140,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun d(tag: String? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(DEBUG, tagOrCaller)) {
-            internalLogger.log(DEBUG, tagOrCaller, message())
+    public inline fun d(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(DEBUG, tag)) {
+            internalLogger.log(DEBUG, tag, message())
         }
     }
 
@@ -161,10 +153,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun v(tag: String? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(VERBOSE, tagOrCaller)) {
-            internalLogger.log(VERBOSE, tagOrCaller, message())
+    public inline fun v(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(VERBOSE, tag)) {
+            internalLogger.log(VERBOSE, tag, message())
         }
     }
 
@@ -175,10 +166,9 @@ public object StreamLog {
      * @param message The function returning a message you would like logged.
      */
     @JvmStatic
-    public inline fun a(tag: String? = null, message: () -> String) {
-        val tagOrCaller = tag ?: outerClassSimpleTagName()
-        if (internalValidator.isLoggable(ASSERT, tagOrCaller)) {
-            internalLogger.log(ASSERT, tagOrCaller, message())
+    public inline fun a(tag: String, message: () -> String) {
+        if (internalValidator.isLoggable(ASSERT, tag)) {
+            internalLogger.log(ASSERT, tag, message())
         }
     }
 

--- a/stream-log/src/main/java/io/getstream/log/StreamLogExtension.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLogExtension.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2014-2022 Stream.io Inc. All rights reserved.
+ *
+ * Licensed under the Stream License;
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://github.com/GetStream/stream-log/blob/main/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.getstream.log
+
+/**
+ * Low-level logging call extension.
+ *
+ * @param priority The priority/type of this log message. [Priority.DEBUG] is default.
+ * @param tag Used to identify the source of a log message.
+ * @param message The message you would like logged.
+ * @param throwable An exception to log.
+ *
+ * @see Priority
+ *
+ * ```
+ * class MainViewModel {
+ *
+ *   fun fetchNetworkItems() {
+ *     streamLog { "Fetching network items.." }
+ *
+ *     val networkItem = repository.networkItems()
+ *
+ *     streamLog { "Network Items: $networkItem" }
+ *   }
+ * }
+ * ```
+ */
+public inline fun Any.streamLog(
+    priority: Priority = Priority.DEBUG,
+    tag: String? = null,
+    throwable: Throwable? = null,
+    message: () -> String,
+) {
+    val tagOrCaller = tag ?: outerClassSimpleTagName()
+    StreamLog.log(priority, tagOrCaller, throwable, message)
+}
+
+/** https://github.com/square/logcat/blob/main/logcat/src/main/java/logcat/Logcat.kt#L87 **/
+@PublishedApi
+internal fun Any.outerClassSimpleTagName(): String {
+
+    val javaClass = this::class.java
+    val fullClassName = javaClass.name
+    val outerClassName = fullClassName.substringBefore('$')
+    val simplerOuterClassName = outerClassName.substringAfterLast('.')
+    return if (simplerOuterClassName.isEmpty()) {
+        fullClassName
+    } else {
+        simplerOuterClassName.removeSuffix("Kt")
+    }
+}

--- a/stream-log/src/main/java/io/getstream/log/StreamLogExtension.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLogExtension.kt
@@ -49,10 +49,8 @@ public inline fun Any.streamLog(
     StreamLog.log(priority, tagOrCaller, throwable, message)
 }
 
-/** https://github.com/square/logcat/blob/main/logcat/src/main/java/logcat/Logcat.kt#L87 **/
 @PublishedApi
 internal fun Any.outerClassSimpleTagName(): String {
-
     val javaClass = this::class.java
     val fullClassName = javaClass.name
     val outerClassName = fullClassName.substringBefore('$')

--- a/stream-log/src/main/java/io/getstream/log/StreamLogExtension.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLogExtension.kt
@@ -49,6 +49,28 @@ public inline fun Any.streamLog(
     StreamLog.log(priority, tagOrCaller, throwable, message)
 }
 
+/**
+ * Return [TaggedLogger] lazily.
+ *
+ * @param tag Used to identify the source of a log message.
+ *
+ * ```
+ * class MainController {
+ *
+ *   val logger by taggedLogger()
+ *
+ *   fun onItemClicked() {
+ *     logger.d { "item clicked" }
+ *   }
+ * }
+ */
+public fun Any.taggedLogger(
+    tag: String? = null,
+): Lazy<TaggedLogger> {
+    val tagOrCaller = tag ?: outerClassSimpleTagName()
+    return lazy { StreamLog.getLogger(tagOrCaller) }
+}
+
 @PublishedApi
 internal fun Any.outerClassSimpleTagName(): String {
     val javaClass = this::class.java

--- a/stream-log/src/main/java/io/getstream/log/StreamLogger.kt
+++ b/stream-log/src/main/java/io/getstream/log/StreamLogger.kt
@@ -56,7 +56,7 @@ public enum class Priority(
     /** Priority for the [StreamLogger.log] method; use [StreamLog.e]. */
     ERROR(level = 6),
 
-    /** Priority for the [StreamLogger.log] method. */
+    /** Priority for the [StreamLogger.log] method; use [StreamLog.a]. */
     ASSERT(level = 7),
 }
 
@@ -65,5 +65,6 @@ public enum class Priority(
  */
 public object SilentStreamLogger : StreamLogger {
 
-    override fun log(priority: Priority, tag: String, message: String, throwable: Throwable?) { /* no-op */ }
+    override fun log(priority: Priority, tag: String, message: String, throwable: Throwable?) { /* no-op */
+    }
 }


### PR DESCRIPTION
### 🎯 Goal

Implemented `streamLog` and `taggedLogger` extensions for logging and getting logger instances more conveniently.

### streamLog
we don't need to get the logger with `StreamLog.getLogger("tag")`. We can use this directly.

```kotlin
class MainViewModel {

  fun fetchNetworkItems() {
    streamLog { "Fetching network items.." }

    val networkItem = repository.networkItems()

    streamLog { "Network Items: $networkItem" }
  }
}
```

### taggedLogger

we don't need to get the logger with `StreamLog.getLogger("tag")`, and initialize the `TaggedLogger` lazily as a property.

```kotlin
 class MainController {
 
   val logger by taggedLogger()
 
   fun onItemClicked() {
     logger.d { "item clicked" }
   }
 }
```