### PR TITLE
Transitive dependencies for each module

### DIFF
--- a/stream-log-android-init/build.gradle
+++ b/stream-log-android-init/build.gradle
@@ -27,9 +27,8 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation project(":stream-log")
+    api project(":stream-log-android")
     implementation project(":stream-log-file")
-    implementation project(":stream-log-android")
 
     implementation Dependencies.androidxCoreKtx
 

--- a/stream-log-android/build.gradle
+++ b/stream-log-android/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation project(":stream-log")
+    api project(":stream-log")
 
     implementation Dependencies.androidxAnnotations
 

--- a/stream-log-file/build.gradle
+++ b/stream-log-file/build.gradle
@@ -30,7 +30,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation project(":stream-log")
+    api project(":stream-log")
 
     testImplementation Dependencies.junit4
 


### PR DESCRIPTION
### 🎯 Goal

Transitive dependencies for each module.

Essentially `stream-log` module is the most basic module and another module must require the `stream-log` to utilize logging. So by making transitive dependencies, so people don't need to declare multiple dependencies.