### PR TITLE
Set the default validator priority as debug for AndroidStreamLogger

### DIFF
--- a/stream-log-android/src/main/kotlin/io/getstream/log/android/AndroidStreamLogger.kt
+++ b/stream-log-android/src/main/kotlin/io/getstream/log/android/AndroidStreamLogger.kt
@@ -80,6 +80,9 @@ public class AndroidStreamLogger constructor(
          */
         public fun installOnDebuggableApp(application: Application, maxTagLength: Int = DEFAULT_MAX_TAG_LENGTH) {
             if (!StreamLog.isInstalled && application.isDebuggableApp) {
+                StreamLog.setValidator { priority, _ ->
+                    priority.level >= Priority.DEBUG.level
+                }
                 StreamLog.install(
                     AndroidStreamLogger(maxTagLength = maxTagLength)
                 )
@@ -92,6 +95,9 @@ public class AndroidStreamLogger constructor(
          * @param maxTagLength The maximum length size of the tag.
          */
         public fun install(maxTagLength: Int = DEFAULT_MAX_TAG_LENGTH) {
+            StreamLog.setValidator { priority, _ ->
+                priority.level >= Priority.DEBUG.level
+            }
             StreamLog.install(
                 AndroidStreamLogger(maxTagLength = maxTagLength)
             )


### PR DESCRIPTION
### 🎯 Goal

Set the default validator priority as debug for AndroidStreamLogger.