### PR TITLE
Add the minPriority parameter to the AndroidStreamLogger

### DIFF
--- a/stream-log-android/api/stream-log-android.api
+++ b/stream-log-android/api/stream-log-android.api
@@ -7,10 +7,10 @@ public final class io/getstream/log/android/AndroidStreamLogger : io/getstream/l
 }
 
 public final class io/getstream/log/android/AndroidStreamLogger$Companion {
-	public final fun install (I)V
-	public static synthetic fun install$default (Lio/getstream/log/android/AndroidStreamLogger$Companion;IILjava/lang/Object;)V
-	public final fun installOnDebuggableApp (Landroid/app/Application;I)V
-	public static synthetic fun installOnDebuggableApp$default (Lio/getstream/log/android/AndroidStreamLogger$Companion;Landroid/app/Application;IILjava/lang/Object;)V
+	public final fun install (Lio/getstream/log/Priority;I)V
+	public static synthetic fun install$default (Lio/getstream/log/android/AndroidStreamLogger$Companion;Lio/getstream/log/Priority;IILjava/lang/Object;)V
+	public final fun installOnDebuggableApp (Landroid/app/Application;Lio/getstream/log/Priority;I)V
+	public static synthetic fun installOnDebuggableApp$default (Lio/getstream/log/android/AndroidStreamLogger$Companion;Landroid/app/Application;Lio/getstream/log/Priority;IILjava/lang/Object;)V
 }
 
 public final class io/getstream/log/android/BuildConfig {

--- a/stream-log-android/src/main/kotlin/io/getstream/log/android/AndroidStreamLogger.kt
+++ b/stream-log-android/src/main/kotlin/io/getstream/log/android/AndroidStreamLogger.kt
@@ -76,31 +76,29 @@ public class AndroidStreamLogger constructor(
          * Install a new [AndroidStreamLogger] if the application is debuggable.
          *
          * @param application Application.
+         * @param minPriority The minimum [Priority] to show up log messages.
          * @param maxTagLength The maximum length size of the tag.
          */
-        public fun installOnDebuggableApp(application: Application, maxTagLength: Int = DEFAULT_MAX_TAG_LENGTH) {
+        public fun installOnDebuggableApp(
+            application: Application,
+            minPriority: Priority = Priority.DEBUG,
+            maxTagLength: Int = DEFAULT_MAX_TAG_LENGTH,
+        ) {
             if (!StreamLog.isInstalled && application.isDebuggableApp) {
-                StreamLog.setValidator { priority, _ ->
-                    priority.level >= Priority.DEBUG.level
-                }
-                StreamLog.install(
-                    AndroidStreamLogger(maxTagLength = maxTagLength)
-                )
+                StreamLog.setValidator { priority, _ -> priority.level >= minPriority.level }
+                StreamLog.install(AndroidStreamLogger(maxTagLength = maxTagLength))
             }
         }
 
         /**
          * Install a new [AndroidStreamLogger].
          *
+         * @param minPriority The minimum [Priority] to show up log messages.
          * @param maxTagLength The maximum length size of the tag.
          */
-        public fun install(maxTagLength: Int = DEFAULT_MAX_TAG_LENGTH) {
-            StreamLog.setValidator { priority, _ ->
-                priority.level >= Priority.DEBUG.level
-            }
-            StreamLog.install(
-                AndroidStreamLogger(maxTagLength = maxTagLength)
-            )
+        public fun install(minPriority: Priority = Priority.DEBUG, maxTagLength: Int = DEFAULT_MAX_TAG_LENGTH) {
+            StreamLog.setValidator { priority, _ -> priority.level >= minPriority.level }
+            StreamLog.install(AndroidStreamLogger(maxTagLength = maxTagLength))
         }
 
         internal const val DEFAULT_MAX_TAG_LENGTH = 23


### PR DESCRIPTION
### 🎯 Goal

Add the `minPriority` parameter to the AndroidStreamLogger.