### PR TITLE
Define java version to 1.8 for stream-log and file modules

### DIFF
--- a/stream-log-file/build.gradle.kts
+++ b/stream-log-file/build.gradle.kts
@@ -13,6 +13,11 @@ rootProject.extra.apply {
 
 apply(from = "$rootDir/scripts/publish-module.gradle")
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
 dependencies {
     testImplementation(Dependencies.junit4)
     detektPlugins(Dependencies.detektFormatting)

--- a/stream-log/build.gradle.kts
+++ b/stream-log/build.gradle.kts
@@ -18,7 +18,6 @@ java {
     targetCompatibility = JavaVersion.VERSION_1_8
 }
 
-
 dependencies {
     testImplementation(Dependencies.junit4)
     detektPlugins(Dependencies.detektFormatting)

--- a/stream-log/build.gradle.kts
+++ b/stream-log/build.gradle.kts
@@ -13,6 +13,12 @@ rootProject.extra.apply {
 
 apply(from = "$rootDir/scripts/publish-module.gradle")
 
+java {
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+}
+
+
 dependencies {
     testImplementation(Dependencies.junit4)
     detektPlugins(Dependencies.detektFormatting)


### PR DESCRIPTION
### 🎯 Goal

Define java version to 1.8 for stream-log and file modules.
