### PR TITLE
Allow null throwable when logging errors

### DIFF
--- a/stream-log/api/android/stream-log.api
+++ b/stream-log/api/android/stream-log.api
@@ -78,6 +78,7 @@ public final class io/getstream/log/StreamLog {
 	public static final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun getInternalLogger ()Lio/getstream/log/StreamLogger;
 	public final fun getInternalValidator ()Lio/getstream/log/IsLoggableValidator;
 	public static final fun getLogger (Ljava/lang/String;)Lio/getstream/log/TaggedLogger;
@@ -113,6 +114,7 @@ public final class io/getstream/log/TaggedLogger {
 	public final fun d (Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Lio/getstream/log/TaggedLogger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun getDelegate ()Lio/getstream/log/StreamLogger;
 	public final fun getTag ()Ljava/lang/String;
 	public final fun getValidator ()Lio/getstream/log/IsLoggableValidator;

--- a/stream-log/api/jvm/stream-log.api
+++ b/stream-log/api/jvm/stream-log.api
@@ -76,6 +76,7 @@ public final class io/getstream/log/StreamLog {
 	public static final fun d (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public static final fun e (Ljava/lang/String;Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Ljava/lang/String;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun getInternalLogger ()Lio/getstream/log/StreamLogger;
 	public final fun getInternalValidator ()Lio/getstream/log/IsLoggableValidator;
 	public static final fun getLogger (Ljava/lang/String;)Lio/getstream/log/TaggedLogger;
@@ -111,6 +112,7 @@ public final class io/getstream/log/TaggedLogger {
 	public final fun d (Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;)V
 	public final fun e (Lkotlin/jvm/functions/Function0;)V
+	public static synthetic fun e$default (Lio/getstream/log/TaggedLogger;Ljava/lang/Throwable;Lkotlin/jvm/functions/Function0;ILjava/lang/Object;)V
 	public final fun getDelegate ()Lio/getstream/log/StreamLogger;
 	public final fun getTag ()Ljava/lang/String;
 	public final fun getValidator ()Lio/getstream/log/IsLoggableValidator;

--- a/stream-log/src/commonMain/kotlin/io/getstream/log/StreamLog.kt
+++ b/stream-log/src/commonMain/kotlin/io/getstream/log/StreamLog.kt
@@ -22,6 +22,7 @@ import io.getstream.log.Priority.INFO
 import io.getstream.log.Priority.VERBOSE
 import io.getstream.log.Priority.WARN
 import kotlin.concurrent.Volatile
+import kotlin.jvm.JvmOverloads
 import kotlin.jvm.JvmStatic
 
 /**
@@ -112,22 +113,10 @@ public object StreamLog {
    * @param message The function returning a message you would like logged.
    */
   @JvmStatic
-  public inline fun e(tag: String, throwable: Throwable, message: () -> String) {
+  @JvmOverloads
+  public inline fun e(tag: String, throwable: Throwable? = null, message: () -> String) {
     if (internalValidator.isLoggable(ERROR, tag)) {
       internalLogger.log(ERROR, tag, message(), throwable)
-    }
-  }
-
-  /**
-   * Send a [ERROR] log message.
-   *
-   * @param tag Used to identify the source of a log message.
-   * @param message The function returning a message you would like logged.
-   */
-  @JvmStatic
-  public inline fun e(tag: String, message: () -> String) {
-    if (internalValidator.isLoggable(ERROR, tag)) {
-      internalLogger.log(ERROR, tag, message())
     }
   }
 
@@ -206,17 +195,13 @@ public object StreamLog {
    */
   @JvmStatic
   public inline fun log(priority: Priority, tag: String, throwable: Throwable? = null, message: () -> String) {
-    if (throwable != null) {
-      e(tag, throwable, message)
-    } else {
-      when (priority) {
-        VERBOSE -> v(tag, message)
-        DEBUG -> d(tag, message)
-        INFO -> i(tag, message)
-        WARN -> w(tag, message)
-        ERROR -> e(tag, message)
-        ASSERT -> a(tag, message)
-      }
+    when (priority) {
+      VERBOSE -> v(tag, message)
+      DEBUG -> d(tag, message)
+      INFO -> i(tag, message)
+      WARN -> w(tag, message)
+      ERROR -> e(tag, throwable, message)
+      ASSERT -> a(tag, message)
     }
   }
 }
@@ -250,20 +235,10 @@ public class TaggedLogger(
    * @param throwable An exception to log.
    * @param message The function returning a message you would like logged.
    */
-  public inline fun e(throwable: Throwable, message: () -> String) {
+  @JvmOverloads
+  public inline fun e(throwable: Throwable? = null, message: () -> String) {
     if (validator.isLoggable(ERROR, tag)) {
       delegate.log(ERROR, tag, message(), throwable)
-    }
-  }
-
-  /**
-   * Send a [ERROR] log message.
-   *
-   * @param message The function returning a message you would like logged.
-   */
-  public inline fun e(message: () -> String) {
-    if (validator.isLoggable(ERROR, tag)) {
-      delegate.log(ERROR, tag, message())
     }
   }
 


### PR DESCRIPTION
### 🎯 Goal
There are some cases where we want to log an error but the exception/throwable can be null, in that case, an `if-else` check needs to be done before logging this error. The StreamLog already handles this case internally.

Imagine the following class:
```
data class Error(
  val message: String,
  val throwable: Throwable? = null
)
```

With previous implementation, we would have something like:
```
fun handleError(error: Error) {
  if (error.throwable != null) {
    logger.e(error.throwable) { error.message }
  } else {
    logger.e { error.message }
  }
  [...]
}
```

That can be changed by:

```
fun handleError(error: Error) {
  logger.e(error.throwable) { error.message }
  [...]
}
```

