### PR TITLE
Add a safe check before before we start writing logs

### DIFF
--- a/stream-log-android-file/src/main/kotlin/io/getstream/log/file/FileStreamLogger.kt
+++ b/stream-log-android-file/src/main/kotlin/io/getstream/log/file/FileStreamLogger.kt
@@ -24,7 +24,6 @@ import java.io.BufferedWriter
 import java.io.Closeable
 import java.io.File
 import java.io.FileOutputStream
-import java.io.IOException
 import java.io.OutputStreamWriter
 import java.io.PrintWriter
 import java.io.Writer
@@ -119,17 +118,15 @@ public class FileStreamLogger(
       if (!internalFile.exists()) {
         try {
           internalFile.createNewFile()
-        } catch (e: IOException) {
-          Log.e("FileInit", "Failed to create file: ${internalFile.absolutePath}", e)
+
+          if (internalFile.canWrite()) {
+            currentFile = internalFile
+            currentWriter = internalFile.fileWriter()
+          }
+        } catch (e: Exception) {
+          Log.e("FileInit", "Failed to create or write to file: ${internalFile.absolutePath}", e)
           return
         }
-      }
-
-      if (internalFile.canWrite()) {
-        currentFile = internalFile
-        currentWriter = internalFile.fileWriter()
-      } else {
-        Log.e("FileInit", "File is not writable: ${internalFile.absolutePath}")
       }
     }
   }


### PR DESCRIPTION
### 🎯 Goal

Resolve file unavailable crash, specially on Chinesse OEMs

```kotlin
Fatal Exception: java.io.FileNotFoundException: /mnt/expand/d741f19b-cac4-44ef-aa92-e8c0402a1b3b/user/0/<packagename>/files/internal_0.txt: open failed: EINVAL (Invalid argument)
       at [libcore.io](http://libcore.io/).IoBridge.open(IoBridge.java:574)
       at [java.io](http://java.io/).FileOutputStream.<init>(FileOutputStream.java:259)
       at io.getstream.log.file.FileStreamLoggerKt.fileWriter(FileStreamLogger.kt:163)
       at io.getstream.log.file.FileStreamLoggerKt.access$fileWriter(FileStreamLogger.kt:1)
       at io.getstream.log.file.FileStreamLogger.initIfNeeded(FileStreamLogger.kt:105)
       at io.getstream.log.file.FileStreamLogger.log$lambda$1(FileStreamLogger.java:69)
       at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
       at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
       at java.lang.Thread.run(Thread.java:1012)
```

       * On some Android 11+ devices (especially Chinese OEMs), we observed that creating files
       * using File(...) and createNewFile() can fail unexpectedly (background/doze modes/RAM cleaning/device cleanup utilities) with FileNotFoundException or EINVAL,
       * even when writing to internal storage.
       * This helper ensures safe creation of files by handling edge cases and logging issues to improve
       * stability across all devices.

### 🛠 Implementation details

Check if file exists and is writable before we start writing to it
